### PR TITLE
Added support for finding songs within nested heos source trees - use…

### DIFF
--- a/pyheos/command.py
+++ b/pyheos/command.py
@@ -150,6 +150,18 @@ class HeosCommands:
         response = await self._connection.command(const.COMMAND_BROWSE_BROWSE, params)
         return response.payload
 
+    async def browse_container(
+        self, source_id: int, container_id: str, start: int, end: int
+    ) -> Sequence[dict]:
+        """Browse a music container."""
+        params = {
+            "sid": source_id,
+            "cid": container_id,
+            "range": "%d,%d" % (start, end),
+        }
+        response = await self._connection.command(const.COMMAND_BROWSE_BROWSE, params)
+        return response.payload
+
     async def play_input(
         self, player_id: int, input_name: str, *, source_player_id: int = None
     ):
@@ -195,6 +207,23 @@ class HeosCommands:
         if media_id is not None:
             params["mid"] = media_id
         await self._connection.command(const.COMMAND_BROWSE_ADD_TO_QUEUE, params)
+
+    async def get_queue(self, player_id: int, start: int, end: int):
+        """Get the queue."""
+        params = {
+            "pid": player_id,
+            "range": "%d,%d" % (start, end),
+        }
+        response = await self._connection.command(const.COMMAND_GET_QUEUE, params)
+        return response.payload
+
+    async def save_queue(self, player_id: int, name: str) -> None:
+        """Save the queue as a playlist."""
+        params = {
+            "pid": player_id,
+            "name": name,
+        }
+        await self._connection.command(const.COMMAND_SAVE_QUEUE, params)
 
     async def get_groups(self) -> Sequence[dict]:
         """Get groups."""

--- a/pyheos/const.py
+++ b/pyheos/const.py
@@ -8,6 +8,7 @@ DEFAULT_TIMEOUT = 10.0
 DEFAULT_RECONNECT_DELAY = 10.0
 DEFAULT_HEART_BEAT = 10.0
 DEFAULT_STEP = 5
+INDEX_CHUNK_SIZE = 50
 
 STATE_CONNECTED = "connected"
 STATE_DISCONNECTED = "disconnected"
@@ -229,6 +230,8 @@ COMMAND_TOGGLE_MUTE = "player/toggle_mute"
 COMMAND_GET_PLAY_MODE = "player/get_play_mode"
 COMMAND_SET_PLAY_MODE = "player/set_play_mode"
 COMMAND_CLEAR_QUEUE = "player/clear_queue"
+COMMAND_GET_QUEUE = "player/get_queue"
+COMMAND_SAVE_QUEUE = "player/save_queue"
 COMMAND_PLAY_NEXT = "player/play_next"
 COMMAND_PLAY_PREVIOUS = "player/play_previous"
 COMMAND_PLAY_QUICK_SELECT = "player/play_quickselect"

--- a/pyheos/player.py
+++ b/pyheos/player.py
@@ -297,6 +297,14 @@ class HeosPlayer:
         """Clear the queue of the player."""
         await self._commands.clear_queue(self._player_id)
 
+    async def get_queue(self, start: int, end: int):
+        """Get the current queue."""
+        return await self._commands.get_queue(self._player_id, start, end)
+
+    async def save_queue(self, playlist_name: str):
+        """Save the queue as a playlist."""
+        await self._commands.save_queue(self.player_id, playlist_name)
+
     async def play_next(self):
         """Clear the queue of the player."""
         await self._commands.play_next(self._player_id)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -57,6 +57,9 @@ class MockHeosDevice:
         self.register(const.COMMAND_HEART_BEAT, None, "system.heart_beat")
         self.register(const.COMMAND_ACCOUNT_CHECK, None, "system.check_account")
         self.register(const.COMMAND_GET_PLAYERS, None, "player.get_players")
+        self.register(
+            const.COMMAND_BROWSE_GET_SOURCES, None, "browse.get_music_sources"
+        )
         self.register(const.COMMAND_GET_PLAY_STATE, None, "player.get_play_state")
         self.register(
             const.COMMAND_GET_NOW_PLAYING_MEDIA, None, "player.get_now_playing_media"

--- a/tests/fixtures/browse.browse_container.json
+++ b/tests/fixtures/browse.browse_container.json
@@ -1,0 +1,18 @@
+{
+  "heos": {
+    "command": "browse/browse",
+    "result": "success",
+    "message": "sid=1024&cid=10&range=0,50&returned=1&count=1"
+  },
+  "payload": [
+    {
+      "container": "yes",
+      "type": "album",
+      "cid": "10/11",
+      "playable": "yes",
+      "name": "Rex Rocks Rotherham",
+      "image_url": "http://example.com/Rex_Rocks_Rotherham.jpg",
+      "artist": "Rex Meathammer"
+    }
+  ]
+}

--- a/tests/fixtures/browse.browse_container_exhausted.json
+++ b/tests/fixtures/browse.browse_container_exhausted.json
@@ -1,0 +1,8 @@
+{
+  "heos": {
+    "command": "browse/browse",
+    "result": "success",
+    "message": "sid=1024&cid=10&range=1,51&returned=0&count=1"
+  },
+  "payload": []
+}

--- a/tests/fixtures/browse.browse_source.json
+++ b/tests/fixtures/browse.browse_source.json
@@ -1,0 +1,18 @@
+{
+  "heos": {
+    "command": "browse/browse",
+    "result": "success",
+    "message": "sid=1024&returned=1&count=1"
+  },
+  "payload": [
+    {
+      "container": "yes",
+      "type": "container",
+      "cid": "10",
+      "playable": "yes",
+      "name": "Rockin Songs",
+      "image_url": "http://example.com/Rockin_Songs.jpg",
+      "artist": "Rex Meathammer"
+    }
+  ]
+}

--- a/tests/fixtures/browse.browse_subcontainer.json
+++ b/tests/fixtures/browse.browse_subcontainer.json
@@ -1,0 +1,19 @@
+{
+  "heos": {
+    "command": "browse/browse",
+    "result": "success",
+    "message": "sid=1024&cid=10/11&range=0,50&returned=1&count=1"
+  },
+  "payload": [
+    {
+      "container": "no",
+      "type": "song",
+      "mid": "10/11/20",
+      "playable": "yes",
+      "name": "Rock Me Plenty",
+      "image_url": "http://example.com/Rex_Rocks_Rotherham.jpg",
+      "artist": "Rex Meathammer",
+      "album": "Rex Rocks Rotherham"
+    }
+  ]
+}

--- a/tests/fixtures/browse.browse_subcontainer_exhausted.json
+++ b/tests/fixtures/browse.browse_subcontainer_exhausted.json
@@ -1,0 +1,8 @@
+{
+  "heos": {
+    "command": "browse/browse",
+    "result": "success",
+    "message": "sid=1024&cid=10/11&range=1,51&returned=0&count=1"
+  },
+  "payload": []
+}

--- a/tests/fixtures/player.get_queue.json
+++ b/tests/fixtures/player.get_queue.json
@@ -1,0 +1,25 @@
+{
+	"heos": {
+		"command": "player/get_queue",
+		"result": "success",
+		"message": "pid=1&range=0,50"
+	},
+	"payload": [{
+			"song": "Song 1",
+			"album": "Album 1",
+			"artist": "Artist 1",
+			"image_url": "http://example.com/image_1.jpg",
+			"qid": 1,
+			"mid": "media_1",
+			"album_id": "album_id_1"
+		}, {
+			"song": "Song 2",
+			"album": "Album 2",
+			"artist": "Artist 2",
+			"image_url": "http://example.com/image_2.jpg",
+			"qid": 2,
+			"mid": "media_2",
+			"album_id": "album_id_2"
+		}
+	]
+}

--- a/tests/fixtures/player.save_queue.json
+++ b/tests/fixtures/player.save_queue.json
@@ -1,0 +1,1 @@
+{"heos": {"command": "player/save_queue", "result": "success", "message": "pid=1&name=Test playlist"}}

--- a/tests/fixtures/player.save_queue_processing.json
+++ b/tests/fixtures/player.save_queue_processing.json
@@ -1,0 +1,1 @@
+{"heos": {"command": "player/save_queue", "result": "success", "message": "command under process&pid=1&name=Test playlist"}}

--- a/tests/test_heos.py
+++ b/tests/test_heos.py
@@ -618,9 +618,6 @@ async def test_players_changed_event_new_ids(mock_device, heos):
 @pytest.mark.asyncio
 async def test_sources_changed_event(mock_device, heos):
     """Test sources changed fires dispatcher."""
-    mock_device.register(
-        const.COMMAND_BROWSE_GET_SOURCES, None, "browse.get_music_sources"
-    )
     await heos.get_music_sources()
     signal = asyncio.Event()
 

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -188,6 +188,48 @@ async def test_clear_queue(mock_device, heos):
 
 
 @pytest.mark.asyncio
+async def test_save_queue(mock_device, heos):
+    """Test saving the queue."""
+    await heos.get_players()
+    player = heos.players.get(1)
+    playlist_name = "Test playlist"
+    args = {
+        "pid": "1",
+        "name": playlist_name,
+    }
+    mock_device.register(const.COMMAND_SAVE_QUEUE, args, "player.save_queue")
+    await player.save_queue(playlist_name)
+
+    # Also test with a 'command under process' response
+    mock_device.register(
+        const.COMMAND_SAVE_QUEUE,
+        args,
+        ["player.save_queue", "player.save_queue_processing"],
+        replace=True,
+    )
+    await player.save_queue(playlist_name)
+
+
+@pytest.mark.asyncio
+async def test_get_queue(mock_device, heos):
+    """Test getting the queue."""
+    await heos.get_players()
+    player = heos.players.get(1)
+    start = 0
+    end = 50
+    args = {
+        "pid": "1",
+        "range": "%d,%d" % (start, end),
+    }
+    mock_device.register(const.COMMAND_GET_QUEUE, args, "player.get_queue")
+    queue = await player.get_queue(start, end)
+    assert [item["song"] for item in queue] == [
+        "Song 1",
+        "Song 2",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_play_input_source(mock_device, heos):
     """Test the play input source."""
     await heos.get_players()

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -1,4 +1,7 @@
 """Tests for the sources module."""
+import pytest
+
+from pyheos import const
 from pyheos.source import HeosSource, InputSource
 
 
@@ -22,3 +25,176 @@ def test_input_str_repr():
     source = InputSource(1, "Test", "Input")
     assert str(source) == "<Test (Input)>"
     assert repr(source) == "<Test (Input) on 1>"
+
+
+@pytest.mark.asyncio
+async def test_browse_source(mock_device, heos):
+    """Test the browse function."""
+    sources = await heos.get_music_sources()
+    local_music_sid = 1024
+    source = sources.get(local_music_sid)
+    args = {"sid": str(local_music_sid)}
+    mock_device.register(const.COMMAND_BROWSE_BROWSE, args, "browse.browse_source")
+    containers = await source.browse()
+    assert len(containers) == 1
+    container = containers[0]
+    assert container.container
+    assert container.container_id == "10"
+    assert container.source_id == local_music_sid  # tests id inheritance
+
+    # Test cannot be used on containers
+    with pytest.raises(RuntimeError) as excinfo:
+        await container.browse()
+
+    assert "Use browse_container instead" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_browse_container(mock_device, heos):
+    """Test the browse_container function."""
+    sources = await heos.get_music_sources()
+    local_music_sid = 1024
+    source = sources.get(local_music_sid)
+    args = {"sid": str(local_music_sid)}
+    mock_device.register(const.COMMAND_BROWSE_BROWSE, args, "browse.browse_source")
+    containers = await source.browse()
+    container = containers[0]
+    start = 0
+    end = 50
+    args = {
+        "sid": str(local_music_sid),
+        "cid": container.container_id,
+        "range": "%d,%d" % (start, end),
+    }
+    mock_device.register(
+        const.COMMAND_BROWSE_BROWSE, args, "browse.browse_container", replace=True
+    )
+    subcontainers = await container.browse_container(start, end)
+    assert len(subcontainers) == 1
+    subcontainer = subcontainers[0]
+    args = {
+        "sid": str(local_music_sid),
+        "cid": subcontainer.container_id,
+        "range": "%d,%d" % (start, end),
+    }
+    mock_device.register(
+        const.COMMAND_BROWSE_BROWSE, args, "browse.browse_subcontainer"
+    )
+    songs = await subcontainer.browse_container(start, end)
+    assert len(songs) == 1
+    song = songs[0]
+    assert not song.container
+    assert song.media_id == "10/11/20"
+    assert song.container_id == subcontainer.container_id  # tests id inheritance
+    assert song.source_id == local_music_sid  # tests id inheritance
+
+    # Test cannot be used on non containers
+    with pytest.raises(RuntimeError) as excinfo:
+        await source.browse_container(start, end)
+
+    assert "Use browse instead" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_get_child_source(mock_device, heos):
+    """Test getting a child source."""
+    sources = await heos.get_music_sources()
+    local_music_sid = 1024
+    source = sources.get(local_music_sid)
+    args = {"sid": str(local_music_sid)}
+    mock_device.register(const.COMMAND_BROWSE_BROWSE, args, "browse.browse_source")
+    containers = await source.browse()
+    container = containers[0]
+
+    search_container = await source.get_child_source(container.name)
+    assert search_container.container_id == container.container_id
+
+    start = 0
+    end = start + const.INDEX_CHUNK_SIZE
+    args = {
+        "sid": str(local_music_sid),
+        "cid": container.container_id,
+        "range": "%d,%d" % (start, end),
+    }
+    mock_device.register(
+        const.COMMAND_BROWSE_BROWSE, args, "browse.browse_container", replace=True
+    )
+    subcontainers = await container.browse_container(start, end)
+    subcontainer = subcontainers[0]
+    start = 1
+    end = start + const.INDEX_CHUNK_SIZE
+    args = {
+        "sid": str(local_music_sid),
+        "cid": container.container_id,
+        "range": "%d,%d" % (start, end),
+    }
+    mock_device.register(
+        const.COMMAND_BROWSE_BROWSE, args, "browse.browse_container_exhausted"
+    )
+
+    search_subcontainer = await container.get_child_source(subcontainer.name)
+    assert search_subcontainer.container_id == subcontainer.container_id
+
+    # Test not found
+    assert await source.get_child_source("Does not exist") is None
+    assert await container.get_child_source("Does not exist") is None
+
+
+@pytest.mark.asyncio
+async def test_index_all(mock_device, heos):
+    """Test the index_all functionality."""
+    sources = await heos.get_music_sources()
+    local_music_sid = 1024
+    source = sources.get(local_music_sid)
+    args = {"sid": str(local_music_sid)}
+    mock_device.register(const.COMMAND_BROWSE_BROWSE, args, "browse.browse_source")
+    containers = await source.browse()
+    container = containers[0]
+    start = 0
+    end = start + const.INDEX_CHUNK_SIZE
+    args = {
+        "sid": str(local_music_sid),
+        "cid": container.container_id,
+        "range": "%d,%d" % (start, end),
+    }
+    mock_device.register(
+        const.COMMAND_BROWSE_BROWSE, args, "browse.browse_container", replace=True
+    )
+    subcontainers = await container.browse_container(start, end)
+    subcontainer = subcontainers[0]
+    args = {
+        "sid": str(local_music_sid),
+        "cid": subcontainer.container_id,
+        "range": "%d,%d" % (start, end),
+    }
+    mock_device.register(
+        const.COMMAND_BROWSE_BROWSE, args, "browse.browse_subcontainer"
+    )
+    songs = await subcontainer.browse_container(start, end)
+    song = songs[0]
+
+    start = 1
+    end = start + const.INDEX_CHUNK_SIZE
+    args = {
+        "sid": str(local_music_sid),
+        "cid": container.container_id,
+        "range": "%d,%d" % (start, end),
+    }
+    mock_device.register(
+        const.COMMAND_BROWSE_BROWSE, args, "browse.browse_container_exhausted"
+    )
+    args = {
+        "sid": str(local_music_sid),
+        "cid": subcontainer.container_id,
+        "range": "%d,%d" % (start, end),
+    }
+    mock_device.register(
+        const.COMMAND_BROWSE_BROWSE, args, "browse.browse_subcontainer_exhausted"
+    )
+
+    song_count = await container.index_all()
+    assert song_count == 1
+    search_subcontainer = await container.get_child_source(subcontainer.name)
+    assert search_subcontainer.container_id == subcontainer.container_id
+    search_song = await search_subcontainer.get_child_source(song.name)
+    assert search_song.media_id == song.media_id


### PR DESCRIPTION
Added support for finding songs within nested heos source trees - usful when using local dlna music servers.

Added the ability to browse container sources.
Containers now inherit the source_id of the parent source.
Songs now inherit the source_id and container_id of the parent source, allowing them to be queued.
Added support for saving the queue as a playlist.
Added support for getting the current queue.

## Description:
When using a local dlna server with heos, the heos sources can be deeply nested and the server often does not support search directly. These changes allow the user to efficiently explore the heos source tree, finding songs and adding them to the queue.

The code works by using the browse commands to build an index for each source. By default, this is done lazily, but an index_all command gives the user the option to recursively build the full index up front.

I have also added support for saving the queue as a playlist.

I developed these chages to allow me to import XSPF playlists (exported from Sonos using soco) into my heos system.

**Related issue (if applicable):** fixes #<pyheos issue number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] Tests have been added/updated. No exclusions in `.coveragerc` permitted.
  - [x] `README.MD` updated (if necessary)