### PR TITLE
Update inputs for CLI 1.16 to support TV and 8K sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![image](https://img.shields.io/pypi/l/pyheos.svg)](https://pypi.org/project/pyheos/)
 [![image](https://img.shields.io/badge/Reviewed_by-Hound-8E64B0.svg)](https://houndci.com)
 
-An async python library for controlling HEOS devices through the HEOS CLI Protocol (version 1.14 for players with firmware 1.505.140 or newer).
+An async python library for controlling HEOS devices through the HEOS CLI Protocol (version 1.16 for players with firmware 1.583.145 or newer).
 
 ## Installation
 ```bash

--- a/pyheos/const.py
+++ b/pyheos/const.py
@@ -113,6 +113,7 @@ INPUT_AUX4 = "inputs/aux4"
 INPUT_AUX5 = "inputs/aux5"
 INPUT_AUX6 = "inputs/aux6"
 INPUT_AUX7 = "inputs/aux7"
+INPUT_AUX_8K = "inputs/aux_8k"
 INPUT_LINE_IN_1 = "inputs/line_in_1"
 INPUT_LINE_IN_2 = "inputs/line_in_2"
 INPUT_LINE_IN_3 = "inputs/line_in_3"
@@ -140,6 +141,7 @@ INPUT_USB_AC = "inputs/usbdac"
 INPUT_ANALOG_IN_1 = "inputs/analog_in_1"
 INPUT_ANALOG_IN_2 = "inputs/analog_in_2"
 INPUT_RECORDER_IN_1 = "inputs/recorder_in_1"
+INPUT_TV = "inputs/tv"
 
 VALID_INPUTS = (
     INPUT_AUX_IN_1,
@@ -154,6 +156,7 @@ VALID_INPUTS = (
     INPUT_AUX5,
     INPUT_AUX6,
     INPUT_AUX7,
+    INPUT_AUX_8K,
     INPUT_LINE_IN_1,
     INPUT_LINE_IN_2,
     INPUT_LINE_IN_3,
@@ -181,6 +184,7 @@ VALID_INPUTS = (
     INPUT_ANALOG_IN_1,
     INPUT_ANALOG_IN_2,
     INPUT_RECORDER_IN_1,
+    INPUT_TV,
 )
 
 # Add to Queue Options


### PR DESCRIPTION
## Description:
Added more input sources per CLI v1.16 spec here: https://rn.dmglobal.com/usmodel/HEOS_CLI_ProtocolSpecification-Version-1.16.pdf

**Related issue (if applicable):**

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [ ] Tests have been added/updated. No exclusions in `.coveragerc` permitted.
  - [x] `README.MD` updated (if necessary)