### PR TITLE
Fix container traversal

### DIFF
--- a/pyheos/command.py
+++ b/pyheos/command.py
@@ -144,9 +144,11 @@ class HeosCommands:
         response = await self._connection.command(const.COMMAND_BROWSE_GET_SOURCES)
         return response.payload
 
-    async def browse(self, source_id: int) -> Sequence[dict]:
+    async def browse(self, source_id: int, container_id: int = None) -> Sequence[dict]:
         """Browse a music source."""
         params = {"sid": source_id}
+        if container_id:
+            params["cid"] = container_id
         response = await self._connection.command(const.COMMAND_BROWSE_BROWSE, params)
         return response.payload
 

--- a/pyheos/source.py
+++ b/pyheos/source.py
@@ -80,7 +80,10 @@ class HeosSource:
 
     async def browse(self) -> "Sequence[HeosSource]":
         """Browse the contents of the current source."""
-        items = await self._commands.browse(self._source_id)
+        items = await self._commands.browse(self._source_id, self._container_id)
+        for i in items:
+            if 'sid' not in i:
+                i['sid'] = self._source_id
         return [HeosSource(self._commands, item) for item in items]
 
     @property

--- a/pyheos/source.py
+++ b/pyheos/source.py
@@ -82,8 +82,8 @@ class HeosSource:
         """Browse the contents of the current source."""
         items = await self._commands.browse(self._source_id, self._container_id)
         for i in items:
-            if 'sid' not in i:
-                i['sid'] = self._source_id
+            if "sid" not in i:
+                i["sid"] = self._source_id
         return [HeosSource(self._commands, item) for item in items]
 
     @property


### PR DESCRIPTION
## Description:
This PR fixes two issues with recursive browsing heos sources. First, we add basic support for browsing source containers by allowing to pass the container_id to the browse/browse command if it is set for the current HeosSource. Note that this variant of browse/browse also supports a range option, which would however require a change to the HeosSource.browse() function.
Secondly, we patch the resulting HeosSource objects by settings their source_id to the source_id of its parent.

I wonder whether we should rather introduce a new HeosContainer class; right now HeosSource plays a slightly surprising double role as a source and a folder (or container) on a source. Maybe this makes sense, I'm really new to this whole API...

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [ ] Tests have been added/updated. No exclusions in `.coveragerc` permitted.
  - [ ] `README.MD` updated (if necessary)